### PR TITLE
ci: use snapshots from central

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -54,7 +54,7 @@ jobs:
           PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: |
           # shellcheck disable=SC2086 
-          mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests -s development/settings.xml
+          mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests
 
       - name: JReleaser output
         if: always()

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,16 +13,16 @@ on:
 permissions:
   contents: read
 
-jobs:
+jobs:  
   version-bump:
     secrets: inherit
     permissions:
       contents: write
-    uses: ./.github/workflows/bump-temporary.yml
+    uses: diggsweden/.github/.github/workflows/version-bump-changelog.yml@main
     with:
       updatePom: true
       file_pattern: pom.xml CHANGELOG.md
-
+  
   release-lib:
     needs: [version-bump]
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,5 @@ jobs:
           PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: |
           # shellcheck disable=SC2086 
-          mvn $MAVEN_CLI_OPTS test -s development/settings.xml
+          mvn $MAVEN_CLI_OPTS test
  

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -87,10 +87,10 @@ commit() {
   printf '\n\n'
 }
 
-format() {
-  print_header 'FORMATTING (GOOGLE STYLE)'
-  mvn formatter:format "${MAVEN_CLI_OPTS[@]}" -DskipTests -s development/settings.xml
-  store_exit_code "$?" "Format" "${MISSING} ${RED}Format check failed, see logs (std out) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Format check passed${NC}\n"
+verify() {
+  print_header 'VERIFY'
+  mvn verify "${MAVEN_CLI_OPTS[@]}"
+  store_exit_code "$?" "Verify" "${MISSING} ${RED}Verify check failed, see logs (std out) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Verify check passed${NC}\n"
   printf '\n\n'
 }
 
@@ -130,7 +130,7 @@ is_command_available 'sed' ''
 
 lint
 commit
-format
+verify
 license
 
 check_exit_codes

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,7 +20,7 @@ NOTE: The given tag will also set the POM-project version.
 ### Maven
 
 ```shell
-mvn clean verify -s development/settings.xml  
+mvn clean verify 
 ```
 
 ### VSCode

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC0-1.0
 
   <groupId>se.digg.wallet</groupId>
   <artifactId>eudiw-wallet-token-lib</artifactId>
-  <version>0.0.8-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>EUDI Wallet -- Token Library</name>
   <description>Library for handling data types in the EUDI Wallet PoC project.</description>
   <url>https://github.com/diggsweden/eudiw-wallet-token-lib</url>
@@ -101,7 +101,7 @@ SPDX-License-Identifier: CC0-1.0
     <dependency>
       <groupId>se.digg.cose</groupId>
       <artifactId>cose-lib</artifactId>
-      <version>2.0.4-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -200,7 +200,6 @@ SPDX-License-Identifier: CC0-1.0
         <configuration>
           <configFile>${project.basedir}/development/formatting/eclipse-java-google-style.xml</configFile>
           <lineEnding>LF</lineEnding>
-          <verbose>true</verbose>          <!-- Add this for more logging -->
           <compilerSource>21</compilerSource>
           <compilerCompliance>21</compilerCompliance>
           <compilerTargetPlatform>21</compilerTargetPlatform>
@@ -278,5 +277,20 @@ SPDX-License-Identifier: CC0-1.0
       </plugin>
     </plugins>
   </build>
+
+  <!-- Snapshots -->
+  <repositories>
+    <repository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
 </project>


### PR DESCRIPTION
Use snapshots from mvn central portal instead of the token based gh-packages fetch

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
