### PR TITLE
ci(releaser): refactor central portal release

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -33,18 +33,34 @@ jobs:
           java-version: 21
           distribution: 'temurin'
           cache: 'maven'
-     
+      
+      - name: Fetch git-cliff templates
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: diggsweden/.github
+          path: .github-templates
+          ref: main
+
           
       - name: Generate Releasenotes
         uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # v4.4.2
         with:
+          config: .github-templates/gitcliff-templates/default.toml
           args: --latest
         env:
           OUTPUT: ReleasenotesTmp
           GITHUB_REPO: ${{ github.repository }}
+       
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        with:
+          gpg_private_key: ${{ secrets.OSPO_BOT_GPG_PRIV }} 
+          passphrase: ${{ secrets.OSPO_BOT_GPG_PASS }}      
       
-      - name: Release with JReleaser
+      - name: Release to Maven Central and GitHub Releases
         env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.OSPO_BOT_GPG_PUB }}
@@ -54,7 +70,10 @@ jobs:
           PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: |
           # shellcheck disable=SC2086 
-          mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests
+          mvn $MAVEN_CLI_OPTS deploy --settings .mvn/settings.xml -Pcentral-release
+
+          # shellcheck disable=SC2086 
+          mvn $MAVEN_CLI_OPTS jreleaser:full-release -DskipTests
 
       - name: JReleaser output
         if: always()

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,9 @@
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -12,6 +12,7 @@ path = [
   "CHANGELOG.md",
  "docs/DEVELOPMENT.md",
   "jreleaser.yml",
+  ".mvn/settings.xml",
   "**/*/pmd_default_java.xml",
   "README.md",
 ]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -2,52 +2,63 @@
 
 This guide outlines core essentials you need to know for developing in this project.
 
-## The Release Workflow
+## Consuming SNAPSHOTS from Maven Central
 
-Activate the CI-workflow with a tag and push.
+Configure your pom.xml file with the following <repositories> section:
 
-Example:
-```shell
-git tag -s v0.0.3-SNAPSHOT -m 'v0.0.3-SNAPSHOT'
-git push origin tag v0.0.3-SNAPSHOT
+```xml
+<repositories>
+  <repository>
+    <name>Central Portal Snapshots</name>
+    <id>central-portal-snapshots</id>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <releases>
+      <enabled>false</enabled>
+    </releases>
+    <snapshots>
+      <enabled>true</enabled>
+    </snapshots>
+  </repository>
+</repositories>
 ```
-Currently only publishing to GitHub-packages, and only SemVer with -SNAPSHOT-prefix.
 
-NOTE: The given tag will also set the POM-project version.
-
-## Formatting and Checkstyle
+## Testing, Formatting and Checkstyle
 
 ### Maven
 
 ```shell
-mvn clean verify 
+mvn clean verify
 ```
+## IDE
 
-### VSCode
+### Setup VSCode
 
 1. Install a Checkstyle plugin - [Checkstyle For Java](https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle)
 
 2. Open workspace settings - settings.json (for example with Ctrl+Shift+P -> Preferences: Workspace Settings (JSON)) and make sure you have the following settings:
 ```json
-    "java.format.settings.url": "${userHome}/development/formatting/eclipse-java-google-style.xml",
+    "[java]": {
+        "editor.defaultFormatter": "redhat.java",
+    },
+    "java.format.settings.url": "development/formatting/eclipse-java-google-style.xml",
     "java.format.settings.profile": "GoogleStyle",
     "editor.formatOnSave": true,
-    "java.checkstyle.configuration": "${userHome}/development/checkstyle/google_checks.xml",
+    "java.checkstyle.configuration": "development/checkstyle/google_checks.xml",
     "java.checkstyle.version": "10.21.2"
 ```
 
-# IntelliJ
+### Setup IntelliJ
 
-### Code Style
-1. Settings -> `Editor -> Code Style -> Java`
-2. Click gear -> `Import Scheme -> Eclipse XML Profile`
-3. Select `development/formatting/eclipse-java-google-style.xml`
+1. Code Style
+   - Settings -> `Editor -> Code Style -> Java`
+   - Click gear -> `Import Scheme -> Eclipse XML Profile`
+   - Select `development/formatting/eclipse-java-google-style.xml`
 
-### Checkstyle
+2. Checkstyle
 
-1. Install "CheckStyle-IDEA" plugin
-2. Settings -> `Tools -> Checkstyle`
-3. Click the built-in Google Style Check
+   - Install "CheckStyle-IDEA" plugin
+   - Settings -> `Tools -> Checkstyle`
+   - Click the built-in Google Style Check
 
 ## Documentation
 
@@ -56,6 +67,29 @@ Generate Javadocs using:
 ```shell
 mvn javadoc:javadoc
 <browser> target/reports/apidocs/index.html
+
+
+```
+## The Release Workflow
+
+Releases to Maven Central can be done in two ways - by CI or by local release.
+
+<TO_DO: described need vars, like gpg key, token>
+
+### Activate the CI-workflow with a tag and push
+
+```shell
+git tag -s v0.0.3-SNAPSHOT -m 'v0.0.3-SNAPSHOT'
+git push origin tag v0.0.3-SNAPSHOT
+```
+NOTE: Always use the same tag for snapshots!! Don't incriminate when using snapshots!!
+
+NOTE: The given tag will also set the POM-project version.
+
+### Release from local
+
+```shell
+mvn deploy --settings .mvn/settings.xml -Pcentral-release
 ```
 
 ## Pull Request Workflow

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -7,7 +7,7 @@ project:
   name: eudiw-wallet-token-lib
   description: A PoC Library to support different token formats for EUDI wallet such as SD-JWT and mDL
   license: EUPL-1.2 
-  copyright: 2025 Digg - The Agency for Digital Government
+  copyright: 2025 diggsweden/eudiw-wallet-token-lib
   inceptionYear: 2025
   authors:
     - Digg - Agency for Digital Government
@@ -39,15 +39,7 @@ signing:
 
 # Maven deployment to GitHub packages
 deploy:
-  maven:
-    github:
-      app:
-        active: ALWAYS
-        url: https://maven.pkg.github.com/diggsweden/eudiw-wallet-token-lib
-        applyMavenCentralRules: true
-        snapshotSupported: true
-        stagingRepositories:           
-          - target/staging-deploy
+  enabled: false
 
 # SBOM generation
 catalog:
@@ -61,7 +53,6 @@ catalog:
         enabled: true
 
 # Syft need to know what to sign
-distributions:
-  library:
-    artifacts:
-      - path: target/eudiw-wallet-token-lib-{{projectVersion}}.jar
+files:
+  artifacts:
+    - path: target/eudiw-wallet-token-lib-{{projectVersion}}.jar

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@ SPDX-License-Identifier: CC0-1.0
     <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
+    <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
     <jreleaser-maven-plugin.version>1.17.0</jreleaser-maven-plugin.version>
     <formatter-maven-plugin.version>2.25.0</formatter-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
@@ -211,39 +212,6 @@ SPDX-License-Identifier: CC0-1.0
         </configuration>
       </plugin>
 
-      <!-- Maven Source Plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>${maven-source-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <!-- Maven Javadoc Plugin -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${maven-javadoc-plugin.version}</version>
-        <configuration>
-          <source>${maven.compiler.source}</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- Formatter plugin -->
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
@@ -308,12 +276,14 @@ SPDX-License-Identifier: CC0-1.0
 
       <!-- Deployment -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
         <configuration>
-          <altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
-          <skip>false</skip>
+          <checksums>all</checksums>
+          <skipPublishing>false</skipPublishing>
+          <publishingServerId>central</publishingServerId>
         </configuration>
       </plugin>
 
@@ -328,6 +298,62 @@ SPDX-License-Identifier: CC0-1.0
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>central-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven.gpg.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Sources -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven.source.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Documentation -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven.javadoc.plugin.version}</version>
+            <configuration>
+              <source>${java.version}</source>
+              <bottom>COSE for Java documentation, generated in {currentYear}.</bottom>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <!-- Repositories -->
   <repositories>


### PR DESCRIPTION
JRelease and the new central portal publishing plugin does not play well, so instead we are letting the new plugin take care of this.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
